### PR TITLE
Fix error in onUserUpdate function when winnerTeam is not defined

### DIFF
--- a/functions/src/users/onUserUpdate.ts
+++ b/functions/src/users/onUserUpdate.ts
@@ -12,18 +12,21 @@ export const onUserUpdate = functions
   .region(EU_WEST_3)
   .firestore.document('users/{userId}')
   .onUpdate((change) => {
+    const uid = change.after.id
     const userProfile = change.after.data() as UserProfile
 
     return db
       .collection('opponents')
-      .doc(userProfile.uid)
+      .doc(uid)
       .set(
         {
-          uid: userProfile.uid,
+          uid,
           avatarUrl:
-            userProfile.profile?.picture?.data?.url ?? userProfile.avatarUrl,
+            (userProfile.profile?.picture?.data?.url ??
+              userProfile.avatarUrl) ||
+            null,
           displayName: userProfile.displayName,
-          winnerTeam: userProfile.winnerTeam,
+          winnerTeam: userProfile.winnerTeam ?? null,
         },
         {
           merge: true,


### PR DESCRIPTION
Cela semble arriver quand l'utilisateur est modifié mais n'a pas encore choisi son équipe gagnante

```
Error: Value for argument "data" is not a valid Firestore document. Cannot use "undefined" as a Firestore value (found in field "winnerTeam"). If you want to ignore undefined values, enable `ignoreUndefinedProperties`.
    at validateUserInput (/workspace/node_modules/@google-cloud/firestore/build/src/serializer.js:271:19)
    at Object.validateUserInput (/workspace/node_modules/@google-cloud/firestore/build/src/serializer.js:263:13)
    at validateDocumentData (/workspace/node_modules/@google-cloud/firestore/build/src/write-batch.js:577:18)
    at WriteBatch.set (/workspace/node_modules/@google-cloud/firestore/build/src/write-batch.js:243:9)
    at DocumentReference.set (/workspace/node_modules/@google-cloud/firestore/build/src/reference.js:349:14)
    at /workspace/build/users/onUserUpdate.js:19:10
    at cloudFunction (/workspace/node_modules/firebase-functions/lib/cloud-functions.js:134:23)
    at /layers/google.nodejs.functions-framework/functions-framework/node_modules/@google-cloud/functions-framework/build/src/invoker.js:199:28
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Voir: https://console.firebase.google.com/u/1/project/euro-2021-prod/functions/health?range=last-24h&functionFilter=